### PR TITLE
configure: Make update_mo depend on LANG_SUPPORT

### DIFF
--- a/configure
+++ b/configure
@@ -106,14 +106,16 @@ def update_po
 end
 
 def update_mo
-  updateMoTask = GetText::Tools::Task.define do |task|
-    task.domain = 'rubyripper'
-    task.files = Dir.glob("lib/**/*.rb") + Dir.glob("bin/*")
-    task.package_name = 'Rubyripper'
-    task.package_version = '#{$rr_version}'
-    task.enable_po = false
+  if ($LANG_SUPPORT.size != 0)
+    updateMoTask = GetText::Tools::Task.define do |task|
+      task.domain = 'rubyripper'
+      task.files = Dir.glob("lib/**/*.rb") + Dir.glob("bin/*")
+      task.package_name = 'Rubyripper'
+      task.package_version = '#{$rr_version}'
+      task.enable_po = false
+    end
+    updateMoTask.invoke
   end
-  updateMoTask.invoke
 end
 
 def check_deps


### PR DESCRIPTION
Resolves:
Could not import gettext; skip language support...
Traceback (most recent call last):
	3: from configure:124:in `<main>'
	2: from configure:124:in `each'
	1: from configure:138:in `block in <main>'
configure:109:in `update_mo': uninitialized constant GetText::Tools::Task (NameError)

Which appears if ruby-gettext (or some of its deps) are not installed.