### PR TITLE
gtk2: ripStatus: ruby 2.5 compliant format strings

### DIFF
--- a/lib/rubyripper/gtk2/ripStatus.rb
+++ b/lib/rubyripper/gtk2/ripStatus.rb
@@ -34,10 +34,10 @@ class RipStatus
   def updateProgress(type, value)
     progress = "%.3g" % (value * 100)
     if type == 'encoding'
-      @encBar.text = _("Encoding progress %s \%") % [progress]
+      @encBar.text = _("Encoding progress %s %%") % [progress]
       @encBar.fraction = value
     else
-      @ripBar.text = _("Ripping progress %s \%") % progress
+      @ripBar.text = _("Ripping progress %s %%") % progress
       @ripBar.fraction = value
     end
   end


### PR DESCRIPTION
Avoids the following crash while extracting a CD with ruby 2.5:
```
 #<Thread:0x00007f3dd82f1710@/bin/rrip_gui:77 run> terminated with exception (report_on_exception is true):
 Traceback (most recent call last):
         2: from /bin/rrip_gui:85:in `block in update'
         1: from /usr/lib/rubyripper/gtk2/ripStatus.rb:40:in `updateProgress'
 /usr/lib/rubyripper/gtk2/ripStatus.rb:40:in `%': incomplete format specifier; use %% (double %) instead (ArgumentError)
 Traceback (most recent call last):
         2: from /bin/rrip_gui:85:in `block in update'
         1: from /usr/lib/rubyripper/gtk2/ripStatus.rb:40:in `updateProgress'
 /usr/lib/rubyripper/gtk2/ripStatus.rb:40:in `%': incomplete format specifier; use %% (double %) instead (ArgumentError)
```