### PR TITLE
Support "other" command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/locale
+/Makefile

--- a/lib/rubyripper/codecs/other.rb
+++ b/lib/rubyripper/codecs/other.rb
@@ -1,0 +1,13 @@
+
+module Codecs
+  class Other
+    # See `Encode#encodeTrack`
+    def name; "other" end
+
+    def extension; "" end
+
+    def replaygain(track); "" end
+
+    def replaygainAlbum; "" end
+  end
+end

--- a/lib/rubyripper/fileScheme.rb
+++ b/lib/rubyripper/fileScheme.rb
@@ -204,9 +204,9 @@ class FileScheme
       end
       @otherExtension = match[1].downcase
       # Now clean the ext we just found
-      # TODO: Is this needed? Seems to break filenames now.
-      #del_range = (match.begin(1)...match.end(1))
-      #@prefs.settingsOther[del_range] = ""
+      # TODO: Is this needed? Seems to break filenames sometimes.
+      del_range = (match.begin(1)...match.end(1))
+      @prefs.settingsOther[del_range] = ""
     end
   end
 

--- a/lib/rubyripper/preferences/setDefaults.rb
+++ b/lib/rubyripper/preferences/setDefaults.rb
@@ -72,8 +72,9 @@ module Preferences
       @data.opus = false
       @data.settingsOpus = '--bitrate 160'
       @data.wav = false
+      @data.settingsWav = ''
       @data.other = false
-      @data.settingsOther = 'flac %i %o.flac'
+      @data.settingsOther = '/my/wav/processor/tool %i %o.ext'
       @data.playlist = true
       @data.maxThreads = 2
       @data.noSpaces = false

--- a/lib/rubyripper/rubyripper.rb
+++ b/lib/rubyripper/rubyripper.rb
@@ -41,11 +41,11 @@ class Rubyripper
     require 'rubyripper/fileScheme'
     @fileScheme = FileScheme.new(@disc, @trackSelection)
     @fileScheme.prepare()
-    
+
     require 'rubyripper/checkConfigBeforeRipping'
     return CheckConfigBeforeRipping.new(@ui, @disc, @trackSelection, @fileScheme).result
   end
-  
+
   # check the existence of the output dir
   def dirStillAvailable
     @fileScheme.dir.values.each{|dir| return false if @file.exists?(dir) }
@@ -86,7 +86,7 @@ class Rubyripper
     require 'rubyripper/secureRip'
     @ripper = SecureRip.new(@trackSelection, @disc, @fileScheme, @log, @encoding)
   end
-  
+
   def waitForCuesheet
     @disc.finishExtendedTocScan(@log)
     @prefs.codecs.each{|codec| @file.write(@fileScheme.getCueFile(codec), @disc.getCuesheet(codec, fileScheme))}
@@ -102,16 +102,16 @@ class Rubyripper
   def autofixCommonMistakes
     freedbHostnameAndUsernameCanNotBeEmpty()
     flacIsNotAllowedToDeleteInputFile() if @prefs.flac
-    repairOtherPrefs() if @prefs.other
+    #repairOtherPrefs() if @prefs.other # TODO: See method comment
     rippingErrorSectorsMustAtLeastEqualRippingNormalSectors()
   end
-  
+
   # otherwise the freedb server returns an error
-  def freedbHostnameAndUsernameCanNotBeEmpty  
+  def freedbHostnameAndUsernameCanNotBeEmpty
     if @prefs.username.strip().empty?
       @prefs.username = 'anonymous'
     end
-    
+
     if @prefs.hostname.strip().empty?
       @prefs.hostname = 'my_secret.com'
     end
@@ -122,28 +122,30 @@ class Rubyripper
     @prefs.settingsFlac = @prefs.settingsFlac.gsub(' --delete-input-file', '')
   end
 
-  def repairOtherprefs
-    copyString = ""
-    lastChar = ""
-
-    #first remove all double quotes. then iterate over each char
-    @prefs.settingsOther.delete('"').split(//).each do |char|
-      if char == '%' # prepend double quote before %
-        copyString << '"' + char
-      elsif lastChar == '%' # append double quote after %char
-        copyString << char + '"'
-      else
-        copyString << char
-      end
-      lastChar = char
-    end
-
-    # above won't work for various artist
-    copyString.gsub!('"%v"a', '"%va"')
-
-    @prefs.settingsOther = copyString
-    puts @prefs.settingsOther if @prefs['debug']
-  end
+  # TODO: Delete this? It does not seem to be needed now, as each `%x` format
+  #       string value is automatically wrapped in quotes at parse time.
+  #def repairOtherPrefs
+  #  copyString = ""
+  #  lastChar = ""
+  #
+  #  #first remove all double quotes. then iterate over each char
+  #  @prefs.settingsOther.delete('"').split(//).each do |char|
+  #    if char == '%' # prepend double quote before %
+  #      copyString << '"' + char
+  #    elsif lastChar == '%' # append double quote after %char
+  #      copyString << char + '"'
+  #    else
+  #      copyString << char
+  #    end
+  #    lastChar = char
+  #  end
+  #
+  #  # above won't work for various artist
+  #  copyString.gsub!('"%v"a', '"%va"')
+  #
+  #  @prefs.settingsOther = copyString
+  #  puts @prefs.settingsOther if @prefs.debug
+  #end
 
   def rippingErrorSectorsMustAtLeastEqualRippingNormalSectors()
     if @prefs.reqMatchesErrors < @prefs.reqMatchesAll

--- a/lib/rubyripper/system/dependency.rb
+++ b/lib/rubyripper/system/dependency.rb
@@ -23,20 +23,20 @@ class Dependency
   include Singleton unless $run_specs
   include GetText
   GetText.bindtextdomain("rubyripper")
-  def self._(txt) ; GetText._(txt) ; end 
-  
+  def self._(txt) ; GetText._(txt) ; end
+
   attr_reader :platform
-  
+
   def initialize(file=nil, platform=nil)
     @platform = platform ? platform : RUBY_PLATFORM
     @file = file ? file : File
   end
-  
+
   # should be triggered by any user interface
   def startupCheck
     checkForcedDeps()
   end
-  
+
   def eject(cdrom)
     Thread.new do
       @exec = Execute.new
@@ -44,13 +44,13 @@ class Dependency
         @exec.launch("eject #{cdrom}")
       #Mac users have diskutil instead of eject
       elsif installed?('diskutil')
-        @exec.launch("diskutil eject #{cdrom}") 
+        @exec.launch("diskutil eject #{cdrom}")
       else
         puts _("WARNING: No eject utility found!")
       end
     end
   end
-  
+
   # opposite of eject
   def closeTray(cdrom)
     if installed?('eject')
@@ -76,7 +76,7 @@ class Dependency
   def env(var)
     return ENV[var]
   end
-  
+
   # an array with dirs in which binary files are launchable
   def path ; ENV['PATH'].split(':') + ['.'] ; end
 
@@ -90,6 +90,7 @@ class Dependency
 
   # A help function to check if an application is installed?
   def installed?(app)
+    return File.executable?(app) if app[0] == "/"
     path.each do |dir|
       return true if File.exist?(File.join(dir, app))
     end
@@ -250,21 +251,21 @@ calculation unless %s is installed.") % ['Discid'],
   # determine default drive
   def getCdrom #default values for cdrom drives under differenty os'es
     case platform
-      when /freebsd/ then drive = getFreebsdDrive()        
+      when /freebsd/ then drive = getFreebsdDrive()
       when /openbsd/ then drive = '/dev/cd0c' # as provided in issue 324
       when /linux|bsd/ then drive = getLinuxDrive()
       when /darwin/ then drive = '/dev/disk1'
     end
-    
+
     return drive ? drive : 'unknown'
   end
-  
+
   def getFreebsdDrive
     (0..9).each{|num| return "/dev/cd#{num}" if @file.exist?("/dev/cd#{num}")}
     (0..9).each{|num| return "/dev/acd#{num}" if @file.exist?("/dev/acd#{num}")}
     return false
   end
-  
+
   def getLinuxDrive
     return '/dev/cdrom' if @file.exist?('/dev/cdrom')
     return '/dev/dvdrom' if @file.exist?('/dev/dvdrom')

--- a/lib/rubyripper/system/execute.rb
+++ b/lib/rubyripper/system/execute.rb
@@ -55,20 +55,25 @@ attr_reader :status
             # normal end of input stream
           rescue Exception => exception
             puts "DEBUG: Command #{command} failed with exception: #{exception.message}" if @prefs.debug
+            output = nil
           end
         end
       rescue
         puts Errors.failedToExecute(program, command)
-        output = ''
+        output = nil
       end
       @filename = filename
     else
       puts Errors.binaryNotFound(program)
+      output = nil
     end
 
+    if    output.nil?   then output = [] # Sentinel for error
+    elsif output.empty? then output = ["OK"] # Command finished ok with no output
+    end
     return output
   end
-  
+
   # return created file with command
   def readFile
     return File.read(@filename) if File.exists?(@filename)


### PR DESCRIPTION
Hello fellow rubyripper. I like what you have done with updates to the code, and your version is now the one that comes from the user repository for my Arch Linux distro.

However I found that my "Other" preference setting to process the wav files from the rip stopped working. I believe I have fixed it here. At least it works for me now, and I added an rspec to prove the new codec interface.

Note that most of the changed lines here are just removal of dead trailing whitespace. You can set the "hide whitespace" option in the Github diff viewer to reduce the number of lines.

I hope you find this useful. Rubyripper is still the best audio ripper for me.