### PR TITLE
disc: Cdrdao: Handle TOC entries containing junk

### DIFF
--- a/lib/rubyripper/disc/scanDiscCdrdao.rb
+++ b/lib/rubyripper/disc/scanDiscCdrdao.rb
@@ -142,6 +142,7 @@ private
 
   def parseCdrdaoFile
     track = nil
+    @contents.encode!('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '?')
     @contents.each_line do |line|
       if line[0..1] == 'CD' && @discType.nil?
         @discType = line.strip()


### PR DESCRIPTION
If a TOC contains garbage characters in an optional field rubyripper would throw the following exception:

    #<Thread:0x000055d0f6a5a4c0 /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:53 run> terminated with exception (report_on_exception is true):
    /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:152:in `block in parseCdrdaoFile': invalid byte sequence in UTF-8 (ArgumentError)
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:145:in `each_line'
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:145:in `parseCdrdaoFile'
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:57:in `block in scanInBackground'
    #<Thread:0x000055d0f7328a48 /usr/bin/rrip_gui:410 run> terminated with exception (report_on_exception is true):
    /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:152:in `block in parseCdrdaoFile': invalid byte sequence in UTF-8 (ArgumentError)
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:145:in `each_line'
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:145:in `parseCdrdaoFile'
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:57:in `block in scanInBackground'
    /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:152:in `block in parseCdrdaoFile': invalid byte sequence in UTF-8 (ArgumentError)
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:145:in `each_line'
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:145:in `parseCdrdaoFile'
    	from /usr/lib/rubyripper/disc/scanDiscCdrdao.rb:57:in `block in scanInBackground'

Scan the read toc data for invalid characters and replace them with '?' before trying to line-split it to avoid trying to handle the invalid UTF-8.

--------

Bought an old Asian CD that has FILE entries in the TOC containing invalid UTF8 bytes, no idea what encoding they are. TOC attached for reference.

[toc.txt](https://github.com/bleskodev/rubyripper/files/12332745/toc.txt)
