### PR TITLE
Fixed the process of migrating "freedb" to "gnudb"

### DIFF
--- a/lib/rubyripper/preferences/cleanup.rb
+++ b/lib/rubyripper/preferences/cleanup.rb
@@ -35,8 +35,8 @@ module Preferences
       if @data.metadataProvider == 'freedb'
         @data.metadataProvider = 'gnudb'
       end
-      if @data.site.include? 'freedb'
-        @data.site.gsub!('freedb', 'gnudb')
+      if @data.site.include? 'freedb.freedb.org'
+        @data.site.gsub!('freedb.freedb.org', 'gnudb.gnudb.org')
       end
     end
 


### PR DESCRIPTION
Fixed an issue I raised where "freedb" was unintentionally replaced: The URL entered into the ”Gnudb server" changes 